### PR TITLE
Fix typo in BossHelper spawn message

### DIFF
--- a/src/main/java/com/p1ut0nium/roughmobsrevamped/misc/BossHelper.java
+++ b/src/main/java/com/p1ut0nium/roughmobsrevamped/misc/BossHelper.java
@@ -81,7 +81,7 @@ public class BossHelper {
 			
 			// Add chat message warning of new boss
 			if (bossWarning) {
-				TextComponentString bossWarningMsg = new TextComponentString(bossName + ", a powreful " + entityType + " leader has joined the battlefield.");
+				TextComponentString bossWarningMsg = new TextComponentString(bossName + ", a powerful " + entityType + " leader, has joined the battlefield.");
 				bossWarningMsg.getStyle().setColor(TextFormatting.RED);
 				bossWarningMsg.getStyle().setBold(true);
 				


### PR DESCRIPTION
Found the typo when scrolling through [reddit](https://www.reddit.com/r/feedthebeast/comments/f6ip4t/what_mod_adds_the_messages_in_red/) and figured I'd contribute a fix.

Fair warning: it's an untested change because I don't have a workspace set up at the moment, but it's literally three characters in some string literals in a glorified print statement. I think we're probably in the clear.